### PR TITLE
Add Google AdSense meta tag to all pages

### DIFF
--- a/About/Cabinet/index.html
+++ b/About/Cabinet/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Cabinet | Charleston Southern University SGA</title>
   <link href="/css/styles.css" rel="stylesheet"/>
   <script src="/js/main.js"></script>

--- a/About/Executives/index.html
+++ b/About/Executives/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Executives | Charleston Southern University SGA</title>
   <link href="/css/styles.css" rel="stylesheet"/>
   <script src="/js/main.js"></script>

--- a/About/Senators/index.html
+++ b/About/Senators/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Senators | Charleston Southern University SGA</title>
   <link href="/css/styles.css" rel="stylesheet"/>
   <script src="/js/main.js"></script>

--- a/About/index.html
+++ b/About/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>About | Charleston Southern University SGA</title>
 
   <link href="/css/styles.css" rel="stylesheet"/>

--- a/Contact/index.html
+++ b/Contact/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Contact Us</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/Events/index.html
+++ b/Events/index.html
@@ -5,6 +5,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="google-adsense-account" content="ca-pub-6248477852052872">
 <title>Events | Charleston Southern University SGA</title>
 <link href="/css/styles.css" rel="stylesheet"/>
 <script src="/js/main.js"></script>

--- a/Idea/index.html
+++ b/Idea/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Submit Idea</title>
   <link rel="stylesheet" href="/css/styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/Media/index.html
+++ b/Media/index.html
@@ -5,6 +5,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="google-adsense-account" content="ca-pub-6248477852052872">
 <title>Media | Charleston Southern University SGA</title>
 <link href="/css/styles.css" rel="stylesheet"/>
 <link href="/css/styles.css" rel="stylesheet"/>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="google-adsense-account" content="ca-pub-6248477852052872">
   <title>Home | Charleston Southern University SGA</title>
 
   <!-- Styles and Fonts -->


### PR DESCRIPTION
## Summary
- add Google AdSense account meta tag to the head of every HTML page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ccac6437083288de8ca9aef62be2d