### PR TITLE
Style About page subpage links as buttons

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -42,11 +42,11 @@
 
       <h2>Our Offices</h2>
       <p>Learn more about the different branches of SGA:</p>
-      <ul>
-        <li><a href="/About/Executives/">Executive Officers</a></li>
-        <li><a href="/About/Cabinet/">Cabinet</a></li>
-        <li><a href="/About/Senators/">Senators</a></li>
-      </ul>
+      <div>
+        <a class="button" href="/About/Executives/">Executive Officers</a>
+        <a class="button" href="/About/Cabinet/">Cabinet</a>
+        <a class="button" href="/About/Senators/">Senators</a>
+      </div>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- Replace bulleted subpage list on About page with styled button links for a cleaner appearance.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da0f5e52c832884b363b85669d06c