### PR TITLE
Center scroll arrows and add scroll to top option

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -450,11 +450,10 @@ footer {
   text-align: center;
 }
 
-/* Scroll-to-top button */
-.scroll-top {
+/* Scroll arrows */
+.scroll-top,
+.scroll-down {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
   width: 40px;
   height: 40px;
   border: none;
@@ -468,7 +467,20 @@ footer {
   transition: opacity 0.3s ease;
 }
 
-.scroll-top.show {
+.scroll-top {
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.scroll-down {
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.scroll-top.show,
+.scroll-down.show {
   opacity: 1;
   pointer-events: auto;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -4,24 +4,43 @@ let submitted = false;
 document.addEventListener("DOMContentLoaded", () => {
   console.log("CSU SGA site loaded.");
 
-  // Scroll-to-top button
+  // Scroll arrows
   const scrollBtn = document.createElement('button');
   scrollBtn.className = 'scroll-top';
   scrollBtn.setAttribute('aria-label', 'Scroll to top');
-  scrollBtn.textContent = '^';
+  scrollBtn.textContent = '↑';
   document.body.appendChild(scrollBtn);
+
+  const scrollDown = document.createElement('button');
+  scrollDown.className = 'scroll-down';
+  scrollDown.setAttribute('aria-label', 'Scroll to bottom');
+  scrollDown.textContent = '↓';
+  document.body.appendChild(scrollDown);
 
   scrollBtn.addEventListener('click', () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });
 
-  window.addEventListener('scroll', () => {
+  scrollDown.addEventListener('click', () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+  });
+
+  const handleScrollButtons = () => {
     if (window.scrollY > 200) {
       scrollBtn.classList.add('show');
     } else {
       scrollBtn.classList.remove('show');
     }
-  });
+
+    if (window.innerHeight + window.scrollY < document.body.offsetHeight - 200) {
+      scrollDown.classList.add('show');
+    } else {
+      scrollDown.classList.remove('show');
+    }
+  };
+
+  window.addEventListener('scroll', handleScrollButtons);
+  handleScrollButtons();
 
   const reveals = document.querySelectorAll(".reveal");
   if (reveals.length) {


### PR DESCRIPTION
## Summary
- Add fixed scroll arrows at the top and bottom of the page
- Introduce scroll-to-top behavior and mirror scroll-down arrow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689350bf45888328a7812617ea87a293