### PR TITLE
Ensure scroll arrows show on all pages

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About | Charleston Southern University SGA</title>
   <link href="/css/styles.css" rel="stylesheet"/>
-  <script src="/js/main.js"></script>
+  <script src="/js/main.js" defer></script>
   <script src="/js/chatbot.js" defer></script>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/Events/index.html
+++ b/Events/index.html
@@ -7,7 +7,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Events | Charleston Southern University SGA</title>
 <link href="/css/styles.css" rel="stylesheet"/>
-<script src="/js/main.js"></script>
+<script src="/js/main.js" defer></script>
 <script src="/js/chatbot.js" defer></script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/Media/index.html
+++ b/Media/index.html
@@ -8,7 +8,7 @@
 <title>Media | Charleston Southern University SGA</title>
 <link href="/css/styles.css" rel="stylesheet"/>
 <link href="/css/styles.css" rel="stylesheet"/>
-<script src="/js/main.js"></script>
+<script src="/js/main.js" defer></script>
 <script src="/js/chatbot.js" defer></script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>


### PR DESCRIPTION
## Summary
- load scroll arrows script with `defer` on About, Events, and Media pages so arrow UI appears consistently

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893577c9c688328ad68d273427bc5af