### PR TITLE
Spreadsheet-based voter verification and standardized student email flow

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -11,6 +11,12 @@
   <div class="wrapper">
     <h1>Executive Editor</h1>
     <div id="editor" style="display:none;">
+      <h2>Voter Verification Roster</h2>
+      <p>Upload an Excel/CSV file with voter name and student email columns.</p>
+      <input id="voter-file" type="file" accept=".xlsx,.xls,.csv" />
+      <button id="upload-voters">Upload Voter Spreadsheet</button>
+      <p id="voter-stats"></p>
+
       <h2>Executives</h2>
       <div id="executives-form"></div>
       <button id="add-executive">Add Executive</button>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
         <a href="/About/">About</a>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
+        <a href="/vote.html">Vote</a>
         <button id="admin-login-btn" class="admin-icon" aria-label="Admin Login">
           <i class="fa-solid fa-user"></i>
         </button>
@@ -37,6 +38,7 @@
         <div class="hero-buttons">
           <button class="button open-chatbot" type="button">Chat with SGA</button>
           <a class="button" href="/Events/">See Events</a>
+          <a class="button" href="/vote.html">Vote Now</a>
         </div>
       </div>
     </header>
@@ -55,6 +57,7 @@
           <h3>Get Involved</h3>
           <p>Join us at upcoming events and make new connections.</p>
           <a class="button" href="/Events/">See Events</a>
+          <a class="button" href="/vote.html">Vote Now</a>
         </div>
         <div class="feature">
           <i class="fa-solid fa-users"></i>

--- a/js/admin.js
+++ b/js/admin.js
@@ -11,6 +11,49 @@ async function loadContent() {
   contentData = await res.json();
 }
 
+async function loadVoterStats() {
+  const stats = document.getElementById('voter-stats');
+  const res = await fetch(`${baseUrl}/api/voters/stats`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!res.ok) {
+    stats.textContent = 'Unable to load voter stats.';
+    return;
+  }
+
+  const data = await res.json();
+  stats.textContent = `Registered voters: ${data.registeredVoters} | Votes cast: ${data.submittedVotes}`;
+}
+
+async function uploadVoterSpreadsheet() {
+  const fileInput = document.getElementById('voter-file');
+  const file = fileInput.files[0];
+  if (!file) {
+    alert('Please choose an Excel/CSV file first.');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('voters', file);
+
+  const res = await fetch(`${baseUrl}/api/voters/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    alert(data.error || 'Failed to upload voter spreadsheet.');
+    return;
+  }
+
+  alert(`Roster uploaded. ${data.registeredVoters} voters available for verification.`);
+  fileInput.value = '';
+  loadVoterStats();
+}
+
 function createEntry(container, item, fields) {
   const div = document.createElement('div');
   fields.forEach(f => {
@@ -110,6 +153,7 @@ function addHandlers() {
     renderAll();
   });
   document.getElementById('save-btn').addEventListener('click', saveContent);
+  document.getElementById('upload-voters').addEventListener('click', uploadVoterSpreadsheet);
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -122,6 +166,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('editor').style.display = 'block';
     renderAll();
     addHandlers();
+    loadVoterStats();
   } catch (e) {
     alert('Failed to load content');
   }

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -4,8 +4,8 @@ const messages = [
   {
     role: "system",
     content: `You are the Charleston Southern University Student Government Association assistant.
-For idea submissions, collect: type of submission (General Feedback or Legislation Idea), category (Campus Life, Campus Recreation, Residence Life, Dining Services, Library, Counseling, Other), detailed description, name (optional), and email (optional).
-For contact requests, collect their name, email, and message.
+For idea submissions, collect: type of submission (General Feedback or Legislation Idea), category (Campus Life, Campus Recreation, Residence Life, Dining Services, Library, Counseling, Other), detailed description, name (optional), and student email in this format only: firstinitialmiddleinitiallastname@student.csuniv.edu (optional).
+For contact requests, collect their name, student email in that same format, and message.
 Ask questions one at a time and keep responses short. After collecting information, summarize it back to the user and thank them.`
   }
 ];

--- a/js/vote.js
+++ b/js/vote.js
@@ -1,0 +1,64 @@
+const EMAIL_DOMAIN = '@student.csuniv.edu';
+
+function normalizeLocalPart(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function suggestedLocalPart(name) {
+  const parts = String(name || '').trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) return '';
+
+  const firstInitial = parts[0][0] || '';
+  const lastName = parts[parts.length - 1] || '';
+  const middleInitials = parts.slice(1, -1).map(part => part[0]).join('');
+  return `${firstInitial}${middleInitials}${lastName}`.replace(/[^a-z0-9]/g, '');
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('vote-form');
+  const nameInput = document.getElementById('voter-name');
+  const localInput = document.getElementById('voter-email-local');
+  const message = document.getElementById('vote-message');
+
+  nameInput.addEventListener('blur', () => {
+    if (localInput.value.trim()) return;
+    const suggested = suggestedLocalPart(nameInput.value);
+    if (suggested) {
+      localInput.value = suggested;
+    }
+  });
+
+  localInput.addEventListener('input', () => {
+    localInput.value = normalizeLocalPart(localInput.value);
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const name = nameInput.value.trim();
+    const localPart = normalizeLocalPart(localInput.value);
+
+    if (!name || !localPart) {
+      message.textContent = 'Please provide both name and email.';
+      return;
+    }
+
+    const email = `${localPart}${EMAIL_DOMAIN}`;
+
+    const res = await fetch('/api/vote', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email })
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      message.textContent = data.error || 'Unable to submit vote.';
+      return;
+    }
+
+    message.textContent = 'Vote submitted and verified successfully.';
+    form.reset();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@huggingface/inference": "^4.6.1",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@huggingface/inference": {
@@ -54,6 +55,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/append-field": {
@@ -137,6 +147,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -208,6 +240,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/debug": {
@@ -376,6 +420,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -978,6 +1031,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1063,11 +1128,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@huggingface/inference": "^4.6.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "xlsx": "^0.18.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,17 +5,58 @@ const crypto = require('crypto');
 const { HfInference } = require('@huggingface/inference');
 const multer = require('multer');
 const cors = require('cors');
+const XLSX = require('xlsx');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
+const EMAIL_DOMAIN = '@student.csuniv.edu';
 const contentFile = path.join(__dirname, 'content.json');
+const dataDir = path.join(__dirname, 'data');
+const voterRegistryFile = path.join(dataDir, 'voter-registry.json');
+const votesFile = path.join(dataDir, 'votes.json');
 let sessionToken = null;
+
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir);
+}
 
 const uploadDir = path.join(__dirname, 'uploads');
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir);
+}
+
+function normalizeName(name) {
+  return String(name || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function normalizeEmail(email) {
+  const raw = String(email || '').trim().toLowerCase();
+  const localPart = raw.replace(EMAIL_DOMAIN, '').replace(/[^a-z0-9]/g, '');
+  return localPart ? `${localPart}${EMAIL_DOMAIN}` : '';
+}
+
+function loadJson(filePath, fallback) {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    console.error(`Failed to read ${filePath}:`, error);
+    return fallback;
+  }
+}
+
+function saveJson(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function readVoterRegistry() {
+  return loadJson(voterRegistryFile, []);
+}
+
+function readVotes() {
+  return loadJson(votesFile, []);
 }
 
 const storage = multer.diskStorage({
@@ -25,7 +66,19 @@ const storage = multer.diskStorage({
     cb(null, unique + path.extname(file.originalname));
   }
 });
+
 const upload = multer({ storage });
+const spreadsheetUpload = multer({
+  storage,
+  fileFilter: (req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (ext === '.xlsx' || ext === '.xls' || ext === '.csv') {
+      cb(null, true);
+      return;
+    }
+    cb(new Error('Only Excel or CSV files are allowed for voter uploads.'));
+  }
+});
 
 function authMiddleware(req, res, next) {
   if (req.headers.authorization !== `Bearer ${sessionToken}`) {
@@ -81,6 +134,99 @@ app.post('/api/upload', authMiddleware, upload.single('media'), (req, res) => {
     return res.status(400).json({ error: 'No file uploaded' });
   }
   res.json({ url: `/uploads/${req.file.filename}` });
+});
+
+app.post('/api/voters/upload', authMiddleware, spreadsheetUpload.single('voters'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No spreadsheet uploaded' });
+  }
+
+  try {
+    const workbook = XLSX.readFile(req.file.path);
+    const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(firstSheet, { defval: '' });
+
+    const registryMap = new Map();
+
+    rows.forEach(row => {
+      const values = Object.values(row).map(value => String(value || '').trim());
+      let name = '';
+      let email = '';
+
+      Object.entries(row).forEach(([key, value]) => {
+        const lower = key.toLowerCase();
+        const text = String(value || '').trim();
+        if (!name && lower.includes('name')) name = text;
+        if (!email && lower.includes('mail')) email = text;
+      });
+
+      if (!name) name = values[0] || '';
+      if (!email) email = values[1] || '';
+
+      const normalizedName = normalizeName(name);
+      const normalizedEmail = normalizeEmail(email);
+
+      if (!normalizedName || !normalizedEmail) return;
+      registryMap.set(normalizedEmail, {
+        name: name.trim(),
+        normalizedName,
+        email: normalizedEmail
+      });
+    });
+
+    const registry = Array.from(registryMap.values());
+    saveJson(voterRegistryFile, registry);
+
+    res.json({
+      status: 'ok',
+      registeredVoters: registry.length,
+      emailFormat: `All emails normalized to *${EMAIL_DOMAIN}`
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(400).json({ error: 'Failed to parse spreadsheet. Ensure it includes name and email columns.' });
+  } finally {
+    fs.unlink(req.file.path, () => {});
+  }
+});
+
+app.get('/api/voters/stats', authMiddleware, (req, res) => {
+  res.json({
+    registeredVoters: readVoterRegistry().length,
+    submittedVotes: readVotes().length
+  });
+});
+
+app.post('/api/vote', (req, res) => {
+  const name = String(req.body.name || '').trim();
+  const email = normalizeEmail(req.body.email);
+
+  if (!name || !email) {
+    return res.status(400).json({ error: 'Name and email are required.' });
+  }
+
+  const registry = readVoterRegistry();
+  const normalizedName = normalizeName(name);
+  const voter = registry.find(entry => entry.email === email && entry.normalizedName === normalizedName);
+
+  if (!voter) {
+    return res.status(403).json({ error: 'Voter verification failed. Please check your name and student email format.' });
+  }
+
+  const votes = readVotes();
+  if (votes.some(v => v.email === email)) {
+    return res.status(409).json({ error: 'This voter has already submitted a vote.' });
+  }
+
+  votes.push({
+    name: voter.name,
+    email,
+    submittedAt: new Date().toISOString(),
+    ballot: req.body.ballot || null
+  });
+  saveJson(votesFile, votes);
+
+  res.json({ status: 'ok', message: 'Vote recorded successfully.' });
 });
 
 app.post('/api/chat', async (req, res) => {

--- a/vote.html
+++ b/vote.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Student Voting | Charleston Southern University SGA</title>
+  <link rel="stylesheet" href="/css/styles.css" />
+  <script src="/js/vote.js" defer></script>
+</head>
+<body>
+  <div class="wrapper">
+    <header>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/About/">About</a>
+        <a href="/Events/">Events</a>
+        <a href="/Media/">Media</a>
+        <a href="/vote.html">Vote</a>
+      </nav>
+      <div class="hero-content">
+        <h1>Student Vote Verification</h1>
+        <p>Enter your name and student email to submit one verified vote.</p>
+      </div>
+    </header>
+
+    <main>
+      <section class="cta reveal full-section">
+        <h2>Cast Your Vote</h2>
+        <form id="vote-form">
+          <input id="voter-name" type="text" placeholder="Full Name" required />
+          <div>
+            <input id="voter-email-local" type="text" placeholder="fmlastname" required />
+            <span>@student.csuniv.edu</span>
+          </div>
+          <button class="button" type="submit">Submit Vote</button>
+        </form>
+        <p id="vote-message"></p>
+      </section>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the previous voter verification with a roster-based workflow so admins can upload an official Excel/CSV roster for verification. 
- Simplify the voter UI to only require `name` and a student email local-part while enforcing a single vote per registered voter. 
- Standardize all student emails to the format `(firstinitial)(middleinitial)(lastname)@student.csuniv.edu` and keep the `@student.csuniv.edu` suffix pre-filled for efficiency.

### Description
- Backend: added `xlsx` parsing, a `data` folder plus `voter-registry.json` and `votes.json`, normalization helpers (`normalizeName`, `normalizeEmail`), and new endpoints `POST /api/voters/upload` to load a roster, `GET /api/voters/stats` for stats, and `POST /api/vote` to verify name+email and record one vote per email in `server.js`.
- Admin UI: added roster upload controls and a voter/vote stats panel in `admin.html` and `js/admin.js` with the `uploadVoterSpreadsheet` and `loadVoterStats` flows to manage verification data from the admin interface.
- Voter UI: added `vote.html` and `js/vote.js` that only ask for full name and the email local-part, prefill `@student.csuniv.edu`, normalize local-part input, and suggest the `firstinitialmiddleinitiallastname` local-part based on name.
- Misc: surfaced voting in the main navigation (`index.html`), updated `js/chatbot.js` guidance to require the standardized student email format, and added `xlsx` to `package.json` for spreadsheet parsing.

### Testing
- Ran `npm test` which reported the project test script (no tests) and completed without error.
- Performed static checks with `node --check server.js && node --check js/admin.js && node --check js/vote.js && node --check js/chatbot.js`, all of which passed.
- Performed an integration smoke test using CLI steps to `POST /api/login`, upload a sample CSV roster to `POST /api/voters/upload`, submit a first vote which succeeded, and submit a second vote with the same email which returned HTTP `409` (duplicate) confirming one-vote-per-voter enforcement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dedabd5fb08328a008aae454838cde)